### PR TITLE
Make compatible with Python 3.6.

### DIFF
--- a/jsonlog-cli/README.md
+++ b/jsonlog-cli/README.md
@@ -2,7 +2,7 @@ jsonlog-cli
 ===========
 
 A human readable formatter for JSON logs.
- 
+
 It's built for use with [jsonlog] but will work well with any log format that
 uses line delimited JSON.
 
@@ -45,6 +45,13 @@ colour each line is printed in (defaults to the `level` key).
 ```bash
 jsonlog --format "{timestamp} {message}" docs/example.log
 ```
+
+Compatibility
+-------------
+
+`jsonlog-cli` is written for Python 3.6 and above. Compatibility patches will be
+accepted for Python 3.5 and above, but patches for Python 2 will be rejected.
+
 
 Authors
 -------

--- a/jsonlog-cli/jsonlog_cli/colours.py
+++ b/jsonlog-cli/jsonlog_cli/colours.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import collections
 import dataclasses
 import typing
@@ -58,11 +56,11 @@ class ColourMap:
         self.mapping = AliasedDict({self.normalise(k): v for k, v in mapping.items()})
 
     @classmethod
-    def empty(cls) -> ColourMap:
+    def empty(cls) -> "ColourMap":
         return cls({})
 
     @classmethod
-    def default(cls) -> ColourMap:
+    def default(cls) -> "ColourMap":
         return cls(
             {
                 "info": Colour(fg="cyan"),

--- a/jsonlog-cli/jsonlog_cli/config.py
+++ b/jsonlog-cli/jsonlog_cli/config.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dataclasses
 import json
 import logging

--- a/jsonlog-cli/jsonlog_cli/key.py
+++ b/jsonlog-cli/jsonlog_cli/key.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dataclasses
 import typing
 
@@ -13,11 +11,11 @@ class Key:
     template: typing.Optional[str] = dataclasses.field(compare=False, default=None)
 
     @classmethod
-    def from_strings(cls, strings: typing.Sequence[str]) -> typing.Sequence[Key]:
+    def from_strings(cls, strings: typing.Sequence[str]) -> typing.Sequence["Key"]:
         return [cls.from_string(k) for k in strings]
 
     @classmethod
-    def from_string(cls, string: str) -> Key:
+    def from_string(cls, string: str) -> "Key":
         return Key(*string.split("=", 1))
 
     def format_key(self) -> str:

--- a/jsonlog-cli/jsonlog_cli/pattern.py
+++ b/jsonlog-cli/jsonlog_cli/pattern.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dataclasses
 import itertools
 import json
@@ -146,18 +144,18 @@ class KeyValuePattern(Pattern):
     def format_value(value: str) -> str:
         return repr(value)
 
-    def replace_keys(self, **kwargs: typing.Sequence[str]) -> KeyValuePattern:
+    def replace_keys(self, **kwargs: typing.Sequence[str]) -> "KeyValuePattern":
         changes = {a: Key.from_strings(keys) for a, keys in kwargs.items()}
         return self.replace(**changes)
 
     def replace_level_key(self, key: typing.Optional[str]):
         return self.replace(level_ley=Key.from_string(key) if key is not None else None)
 
-    def add_multiline_keys(self, keys: typing.Sequence[str]) -> KeyValuePattern:
+    def add_multiline_keys(self, keys: typing.Sequence[str]) -> "KeyValuePattern":
         multiline_keys = Key.from_strings(keys)
         return self.replace(multiline_keys=(*self.multiline_keys, *multiline_keys))
 
-    def remove_keys(self, keys: typing.Sequence[str]) -> KeyValuePattern:
+    def remove_keys(self, keys: typing.Sequence[str]) -> "KeyValuePattern":
         removed_keys = Key.from_strings(keys)
         return self.replace(
             removed_keys=[*self.removed_keys, *removed_keys],

--- a/jsonlog-cli/jsonlog_cli/record.py
+++ b/jsonlog-cli/jsonlog_cli/record.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dataclasses
 import typing
 

--- a/jsonlog-cli/jsonlog_cli/record.py
+++ b/jsonlog-cli/jsonlog_cli/record.py
@@ -4,6 +4,11 @@ import typing
 import jsonlog
 from .key import Key
 
+try:
+    from typing import Protocol  # Only available since python 3.8.
+except ImportError:
+    from typing_extensions import Protocol
+
 log = jsonlog.getLogger(__name__)
 
 RecordKey = str
@@ -59,6 +64,6 @@ class Record(typing.Mapping[str, typing.Any]):
         return self.data[item]
 
 
-class RecordFormatter(typing.Protocol):
+class RecordFormatter(Protocol):
     def format_record(self, record: Record) -> str:
         ...

--- a/jsonlog-cli/jsonlog_cli/record.py
+++ b/jsonlog-cli/jsonlog_cli/record.py
@@ -7,7 +7,7 @@ from .key import Key
 try:
     from typing import Protocol  # Only available since python 3.8.
 except ImportError:
-    from typing_extensions import Protocol
+    from typing_extensions import Protocol  # type: ignore
 
 log = jsonlog.getLogger(__name__)
 

--- a/jsonlog-cli/jsonlog_cli/stream.py
+++ b/jsonlog-cli/jsonlog_cli/stream.py
@@ -14,7 +14,7 @@ import jsonlog_cli.text
 try:
     from typing import Protocol  # Only available since python 3.8.
 except ImportError:
-    from typing_extensions import Protocol
+    from typing_extensions import Protocol  # type: ignore
 
 log = logging.getLogger(__name__)
 

--- a/jsonlog-cli/jsonlog_cli/stream.py
+++ b/jsonlog-cli/jsonlog_cli/stream.py
@@ -11,13 +11,18 @@ import jsonlog_cli.pattern
 import jsonlog_cli.record
 import jsonlog_cli.text
 
+try:
+    from typing import Protocol  # Only available since python 3.8.
+except ImportError:
+    from typing_extensions import Protocol
+
 log = logging.getLogger(__name__)
 
 RecordData = typing.Optional[jsonlog_cli.record.RecordDict]
 RecordPair = typing.Tuple[str, RecordData]
 
 
-class TextStream(typing.Protocol):
+class TextStream(Protocol):
     def __iter__(self) -> typing.Iterator[str]:
         ...
 

--- a/jsonlog-cli/jsonlog_cli/stream.py
+++ b/jsonlog-cli/jsonlog_cli/stream.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import dataclasses
 import json
 import logging
@@ -117,7 +115,7 @@ class StreamHandler:
     color: bool = dataclasses.field(default=True)
     error: bool = dataclasses.field(default=False, init=False)
 
-    def __enter__(self) -> StreamHandler:
+    def __enter__(self) -> "StreamHandler":
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/jsonlog-cli/poetry.lock
+++ b/jsonlog-cli/poetry.lock
@@ -211,7 +211,7 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.8.1"
+version = "1.8.2"
 
 [[package]]
 category = "dev"
@@ -307,7 +307,7 @@ python-versions = "*"
 version = "1.4.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 name = "typing-extensions"
 optional = false
@@ -344,7 +344,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "ad4f752d8c2dcb85d54acf5396ed3b38aa3a27135e6053a6d53cf47e9c307e26"
+content-hash = "cfeb5c3a07a243305605fc46dd44b7f4856cd060d90e40ad280dcd53516712bf"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -429,8 +429,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 py = [
-    {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
-    {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+    {file = "py-1.8.2-py2.py3-none-any.whl", hash = "sha256:a673fa23d7000440cc885c17dbd34fafcb7d7a6e230b29f6766400de36a33c44"},
+    {file = "py-1.8.2.tar.gz", hash = "sha256:f3b3a4c36512a4c4f024041ab51866f11761cc169670204b235f6b20523d4e6b"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},

--- a/jsonlog-cli/pyproject.toml
+++ b/jsonlog-cli/pyproject.toml
@@ -13,6 +13,7 @@ python = "^3.6"
 click = "*"
 jsonlog = "*"
 jsonschema = "*"
+typing-extensions = "*; python_version<3.8"
 xdg = "*"
 
 [tool.poetry.dev-dependencies]

--- a/jsonlog/README.md
+++ b/jsonlog/README.md
@@ -41,7 +41,7 @@ The `jsonlog.basicConfig` function accepts slightly different parameters to
 
 The `filename`, `filemode` and `stream` parameters work the same way as their
 equivalents in `logging.basicConfig`, and as such `filename` and `stream` are
-exclusive. 
+exclusive.
 
 ```python
 import jsonlog
@@ -60,7 +60,7 @@ jsonlog.basicConfig(
 ### Configuration using `logging.config.dictConfig`
 
 Any of the configuration methods in `logging.config` can be used to configure a
-handler that uses `jsonlog.formmatters.JSONFormatter` to format records as JSON. 
+handler that uses `jsonlog.formmatters.JSONFormatter` to format records as JSON.
 
 ```python
 import logging.config
@@ -140,12 +140,12 @@ Traceback (most recent call last):
   File "examples/error.py", line 6, in <module>
     raise ValueError("Example exception")
 ValueError: Example exception
-``` 
+```
 
 Compatibility
 -------------
 
-`jsonlog` is written for Python 3.7 and above. Compatibility patches will be
+`jsonlog` is written for Python 3.6 and above. Compatibility patches will be
 accepted for Python 3.5 and above, but patches for Python 2 will be rejected.
 
 References

--- a/jsonlog/poetry.lock
+++ b/jsonlog/poetry.lock
@@ -67,6 +67,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "0.4.3"
 
 [[package]]
+category = "main"
+description = "A backport of the dataclasses module for Python 3.6"
+name = "dataclasses"
+optional = false
+python-versions = "*"
+version = "0.6"
+
+[[package]]
 category = "dev"
 description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
@@ -181,7 +189,7 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.8.1"
+version = "1.8.2"
 
 [[package]]
 category = "dev"
@@ -295,7 +303,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "d8f425bd576d84c09024af4b23e05d01b2180824aa28ceb7e50a112311deb1bd"
+content-hash = "a899edac6e3b3377bd0ef1ba985fd2b457685633b2d7ac4fda1c68a55f05fd0b"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -322,6 +330,10 @@ click = [
 colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+]
+dataclasses = [
+    {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
+    {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
 ]
 flake8 = [
     {file = "flake8-3.8.3-py2.py3-none-any.whl", hash = "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c"},
@@ -372,8 +384,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 py = [
-    {file = "py-1.8.1-py2.py3-none-any.whl", hash = "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"},
-    {file = "py-1.8.1.tar.gz", hash = "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa"},
+    {file = "py-1.8.2-py2.py3-none-any.whl", hash = "sha256:a673fa23d7000440cc885c17dbd34fafcb7d7a6e230b29f6766400de36a33c44"},
+    {file = "py-1.8.2.tar.gz", hash = "sha256:f3b3a4c36512a4c4f024041ab51866f11761cc169670204b235f6b20523d4e6b"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},

--- a/jsonlog/pyproject.toml
+++ b/jsonlog/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.6"
+dataclasses = "*; python_version<3.7"
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"


### PR DESCRIPTION
This fixes #1 (and is basically only the changes outlined there).

Locally, tests, flake8 and mypy pass but using the GitHub actions CI `test / jsonlog-cli (3.6)` still fails. I think this is because of a bug in the CI setup, because (if I understand it correctly) it pulls the latest `jsonlog` version from PyPI and not the local directory. Not sure how to configure that, however.

Would be happy, if a new version could be pushed to PyPI once this is merged, so I can easily use it in my projects.